### PR TITLE
[docs] Fixing typos in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Learn more at:
 * [Try it live](https://fiverr.github.io/passable/try)
 
 # What is Passable
-Passable is a system for javascript applications that allows you to write structured data model validations in a way that's consistent all accross your app, and fully reusable.
+Passable is a system for javascript applications that allows you to write structured data model validations in a way that's consistent all across your app, and fully reusable.
 
 Inspired by the world of unit testing, Passable validations are written like actual specs that need to be passed, and are considered to be an enforceable contract between the backend and the client. The syntax is very similar, adapted to be more suitable for testing data model, and runs in production code - not in testing environment.
 
@@ -24,6 +24,6 @@ The basic notion behind Passable is that you would want to structure your data m
 
 ### Isomorphic Validations
 
-The other use of Passable is server side validations. Since most of the times we perform validations, we send the data back to the server, we would like to perform the tests there as well. This causes a great deal of confusion and error. It is hard to keep the validations in the server and the client synced, so if we update a validation in the client side, or the server, it is easy to neglet and change it on the other side as well. Even if we do keep them up to date, it is easy, especially if the server and the client are written in different languages, to have a slightly different interpertation of the logic on each end, whic, eventually, causes inconsistencies and bugs.
+The other use of Passable is server side validations. Since most of the times we perform validations, we send the data back to the server, we would like to perform the tests there as well. This causes a great deal of confusion and error. It is hard to keep the validations in the server and the client synced, so if we update a validation in the client side, or the server, it is easy to neglect and change it on the other side as well. Even if we do keep them up to date, it is easy, especially if the server and the client are written in different languages, to have a slightly different interpretation of the logic on each end, which, eventually, causes inconsistencies and bugs.
 
 Instead, with Passable, you could just as easily set up a data model validations server that would run the same exact validation code that runs in the browser. No duplication, no sync problems.

--- a/_docs/enforce/rules/content/inside/README.md
+++ b/_docs/enforce/rules/content/inside/README.md
@@ -16,7 +16,7 @@ The inside rule returns a boolean. `true` for matched values, and `false` for no
 ### inside: array
 Checks for membership in an array.
 
-srting: checks if a string is an element in an array
+string: checks if a string is an element in an array
 
 ```js
 enforce('hello').allOf({

--- a/_docs/enforce/rules/content/matches/README.md
+++ b/_docs/enforce/rules/content/matches/README.md
@@ -4,7 +4,7 @@
 Checks if a value contains a regex match.
 
 ## Arguments
-* `value`: the value which you would like to test against the rexep
+* `value`: the value which you would like to test against the regular expression
 * `regexp`: either a `RegExp` object, or a RegExp valid string
 
 ## Response

--- a/_docs/enforce/rules/size/larger_than/README.md
+++ b/_docs/enforce/rules/size/larger_than/README.md
@@ -5,7 +5,7 @@ Returns true if a given value is larger than another value. The values do not ha
 
 ## Arguments
 * `value`: the value which you would like to test. can be:
-* `target` the value which you woul like your initial object to be tested against
+* `target` the value which you would like your initial object to be tested against
 
 Both arguments can be of the following types:
 * object: checks against count of keys

--- a/_docs/enforce/rules/size/larger_than_or_equals/README.md
+++ b/_docs/enforce/rules/size/larger_than_or_equals/README.md
@@ -5,7 +5,7 @@ Returns true if a given value is larger than or equals another value. The values
 
 ## Arguments
 * `value`: the value which you would like to test. can be:
-* `target` the value which you woul like your initial object to be tested against
+* `target` the value which you would like your initial object to be tested against
 
 Both arguments can be of the following types:
 * object: checks against count of keys

--- a/_docs/enforce/rules/size/size_equals/README.md
+++ b/_docs/enforce/rules/size/size_equals/README.md
@@ -1,11 +1,11 @@
 # Size | sizeEquals
 
 ## Description
-Returns true if a given value eauqls the size than another value. The values do not have to be of the same type
+Returns true if a given value equals the size than another value. The values do not have to be of the same type
 
 ## Arguments
 * `value`: the value which you would like to test. can be:
-* `target` the value which you woul like your initial object to be tested against
+* `target` the value which you would like your initial object to be tested against
 
 Both arguments can be of the following types:
 * object: checks against count of keys

--- a/_docs/enforce/rules/size/smaller_than/README.md
+++ b/_docs/enforce/rules/size/smaller_than/README.md
@@ -5,7 +5,7 @@ Returns true if a given value is smaller than another value. The values do not h
 
 ## Arguments
 * `value`: the value which you would like to test. can be:
-* `target` the value which you woul like your initial object to be tested against
+* `target` the value which you would like your initial object to be tested against
 
 Both arguments can be of the following types:
 * object: checks against count of keys

--- a/_docs/enforce/rules/size/smaller_than_or_equals/README.md
+++ b/_docs/enforce/rules/size/smaller_than_or_equals/README.md
@@ -5,7 +5,7 @@ Returns true if a given value is smaller than or equals another value. The value
 
 ## Arguments
 * `value`: the value which you would like to test. can be:
-* `target` the value which you woul like your initial object to be tested against
+* `target` the value which you would like your initial object to be tested against
 
 Both arguments can be of the following types:
 * object: checks against count of keys

--- a/_docs/getting_started/params.md
+++ b/_docs/getting_started/params.md
@@ -3,8 +3,8 @@
 | Name       | Optional? | type     | Description                                                               |
 |------------|:---------:|:--------:|---------------------------------------------------------------------------|
 | `name`     | No        | String   | A name for the group of tests. E.G - form name                            |
-| `specific` | Yes       | Array    | Whitelist of tests to run. Can be completely ommitted                     |
+| `specific` | Yes       | Array    | Whitelist of tests to run. Can be completely omitted                     |
 | `passes`   | No        | Function | A function containing the actual validation logic.                        |
-| `custom`   | Yes       | Object   | Custom rules to extend the basic ruleset with. Can be completely ommitted |
+| `custom`   | Yes       | Object   | Custom rules to extend the basic ruleset with. Can be completely omitted |
 
 ![alt tag](https://raw.githubusercontent.com/fiverr/passable/master/docs/assets/passable-api.jpg)

--- a/_docs/getting_started/writing_tests.md
+++ b/_docs/getting_started/writing_tests.md
@@ -5,7 +5,7 @@
  * `pass` - a single tests, most commonly a single field, much like the it function in unit tests.
  * `enforce` - the function which gets and enforces the data model compliance, similar to the expect function in unit tests.
 
-The most basic test would looke somewhat like this:
+The most basic test would look somewhat like this:
 
 ```js
 // data = {
@@ -30,6 +30,6 @@ Passable('NewUserForm', (pass, enforce) => {
 });
 ```
 
-In the example above, we tested a form named `NewUserForm`, and ran two tets on it. One of the `username` field, and one on the `age` field. When testing the username field, we made sure that **all** conditions are true, and when testing age, we made sure that **at least one** condition is true.
+In the example above, we tested a form named `NewUserForm`, and ran two tests on it. One of the `username` field, and one on the `age` field. When testing the username field, we made sure that **all** conditions are true, and when testing age, we made sure that **at least one** condition is true.
 
 If our validation fails, among other information, we would get the names of the fields, and an array of errors for each, so we can show them back to the user.

--- a/docs/enforce/rules/content/inside/index.html
+++ b/docs/enforce/rules/content/inside/index.html
@@ -113,7 +113,7 @@
 <h2 id="usage-examples:">usage examples:</h2>
 <h3 id="inside:-array">inside: array</h3>
 <p>Checks for membership in an array.</p>
-<p>srting: checks if a string is an element in an array</p>
+<p>string: checks if a string is an element in an array</p>
 <pre><code class="lang-js">enforce(<span class="pl-s">&apos;hello&apos;</span>).allOf({
     <span class="hljs-attr">inside</span>: [<span class="pl-s">&apos;hello&apos;</span>, <span class="pl-s">&apos;world&apos;</span>]
 });

--- a/docs/enforce/rules/content/matches/index.html
+++ b/docs/enforce/rules/content/matches/index.html
@@ -98,7 +98,7 @@
 <p>Checks if a value contains a regex match.</p>
 <h2 id="arguments">Arguments</h2>
 <ul>
-<li><code>value</code>: the value which you would like to test against the rexep</li>
+<li><code>value</code>: the value which you would like to test against the regular expression</li>
 <li><code>regexp</code>: either a <code>RegExp</code> object, or a RegExp valid string</li>
 </ul>
 <h2 id="response">Response</h2>

--- a/docs/enforce/rules/size/larger_than/index.html
+++ b/docs/enforce/rules/size/larger_than/index.html
@@ -99,7 +99,7 @@
 <h2 id="arguments">Arguments</h2>
 <ul>
 <li><code>value</code>: the value which you would like to test. can be:</li>
-<li><code>target</code> the value which you woul like your initial object to be tested against</li>
+<li><code>target</code> the value which you would like your initial object to be tested against</li>
 </ul>
 <p>Both arguments can be of the following types:</p>
 <ul>

--- a/docs/enforce/rules/size/larger_than_or_equals/index.html
+++ b/docs/enforce/rules/size/larger_than_or_equals/index.html
@@ -99,7 +99,7 @@
 <h2 id="arguments">Arguments</h2>
 <ul>
 <li><code>value</code>: the value which you would like to test. can be:</li>
-<li><code>target</code> the value which you woul like your initial object to be tested against</li>
+<li><code>target</code> the value which you would like your initial object to be tested against</li>
 </ul>
 <p>Both arguments can be of the following types:</p>
 <ul>

--- a/docs/enforce/rules/size/size_equals/index.html
+++ b/docs/enforce/rules/size/size_equals/index.html
@@ -95,11 +95,11 @@
         </div>
         <div class="markdown-body"><h1 id="size-or-sizeequals">Size | sizeEquals</h1>
 <h2 id="description">Description</h2>
-<p>Returns true if a given value eauqls the size than another value. The values do not have to be of the same type</p>
+<p>Returns true if a given value equals the size than another value. The values do not have to be of the same type</p>
 <h2 id="arguments">Arguments</h2>
 <ul>
 <li><code>value</code>: the value which you would like to test. can be:</li>
-<li><code>target</code> the value which you woul like your initial object to be tested against</li>
+<li><code>target</code> the value which you would like your initial object to be tested against</li>
 </ul>
 <p>Both arguments can be of the following types:</p>
 <ul>

--- a/docs/enforce/rules/size/smaller_than/index.html
+++ b/docs/enforce/rules/size/smaller_than/index.html
@@ -99,7 +99,7 @@
 <h2 id="arguments">Arguments</h2>
 <ul>
 <li><code>value</code>: the value which you would like to test. can be:</li>
-<li><code>target</code> the value which you woul like your initial object to be tested against</li>
+<li><code>target</code> the value which you would like your initial object to be tested against</li>
 </ul>
 <p>Both arguments can be of the following types:</p>
 <ul>

--- a/docs/enforce/rules/size/smaller_than_or_equals/index.html
+++ b/docs/enforce/rules/size/smaller_than_or_equals/index.html
@@ -99,7 +99,7 @@
 <h2 id="arguments">Arguments</h2>
 <ul>
 <li><code>value</code>: the value which you would like to test. can be:</li>
-<li><code>target</code> the value which you woul like your initial object to be tested against</li>
+<li><code>target</code> the value which you would like your initial object to be tested against</li>
 </ul>
 <p>Both arguments can be of the following types:</p>
 <ul>

--- a/docs/getting_started/params.html
+++ b/docs/getting_started/params.html
@@ -104,7 +104,7 @@
 <td><code>specific</code></td>
 <td style="text-align:center">Yes</td>
 <td style="text-align:center">Array</td>
-<td>Whitelist of tests to run. Can be completely ommitted</td>
+<td>Whitelist of tests to run. Can be completely omitted</td>
 </tr>
 <tr>
 <td><code>passes</code></td>
@@ -116,7 +116,7 @@
 <td><code>custom</code></td>
 <td style="text-align:center">Yes</td>
 <td style="text-align:center">Object</td>
-<td>Custom rules to extend the basic ruleset with. Can be completely ommitted</td>
+<td>Custom rules to extend the basic ruleset with. Can be completely omitted</td>
 </tr>
 </tbody>
 </table>

--- a/docs/getting_started/writing_tests.html
+++ b/docs/getting_started/writing_tests.html
@@ -90,7 +90,7 @@
 <li><code>pass</code> - a single tests, most commonly a single field, much like the it function in unit tests.</li>
 <li><code>enforce</code> - the function which gets and enforces the data model compliance, similar to the expect function in unit tests.</li>
 </ul>
-<p>The most basic test would looke somewhat like this:</p>
+<p>The most basic test would look somewhat like this:</p>
 <pre><code class="lang-js"><span class="pl-c">// data = {</span>
 <span class="pl-c">//     username: &apos;ealush&apos;,</span>
 <span class="pl-c">//     age: 27</span>
@@ -112,7 +112,7 @@ Passable(<span class="pl-s">&apos;NewUserForm&apos;</span>, (pass, enforce) =&gt
     })
 });
 </code></pre>
-<p>In the example above, we tested a form named <code>NewUserForm</code>, and ran two tets on it. One of the <code>username</code> field, and one on the <code>age</code> field. When testing the username field, we made sure that <strong>all</strong> conditions are true, and when testing age, we made sure that <strong>at least one</strong> condition is true.</p>
+<p>In the example above, we tested a form named <code>NewUserForm</code>, and ran two tests on it. One of the <code>username</code> field, and one on the <code>age</code> field. When testing the username field, we made sure that <strong>all</strong> conditions are true, and when testing age, we made sure that <strong>at least one</strong> condition is true.</p>
 <p>If our validation fails, among other information, we would get the names of the fields, and an array of errors for each, so we can show them back to the user.</p>
 
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,14 +102,14 @@
 <li><a href="https://fiverr.github.io/passable/try">Try it live</a></li>
 </ul>
 <h1 id="what-is-passable">What is Passable</h1>
-<p>Passable is a system for javascript applications that allows you to write structured data model validations in a way that&apos;s consistent all accross your app, and fully reusable.</p>
+<p>Passable is a system for javascript applications that allows you to write structured data model validations in a way that&apos;s consistent all across your app, and fully reusable.</p>
 <p>Inspired by the world of unit testing, Passable validations are written like actual specs that need to be passed, and are considered to be an enforceable contract between the backend and the client. The syntax is very similar, adapted to be more suitable for testing data model, and runs in production code - not in testing environment.</p>
 <p><img src="https://raw.githubusercontent.com/fiverr/passable/master/docs/assets/passable_diagram.png" alt="alt tag"></p>
 <h2 id="key-benefits">Key Benefits</h2>
 <h3 id="structured-validations">Structured Validations</h3>
 <p>The basic notion behind Passable is that you would want to structure your data model validation in your application, in a way that&apos;s consistent and easy to follow. It isn&apos;t much of a problem in a smaller scale application, but as the application gets larger, and more complex, it gets harder to keep track of the different flows of the application and the ways data model validations are performed in each one. Passable gives you a consistent structure to construct your data model validations, in a way that&apos;s both reusable and easy to read.</p>
 <h3 id="isomorphic-validations">Isomorphic Validations</h3>
-<p>The other use of Passable is server side validations. Since most of the times we perform validations, we send the data back to the server, we would like to perform the tests there as well. This causes a great deal of confusion and error. It is hard to keep the validations in the server and the client synced, so if we update a validation in the client side, or the server, it is easy to neglet and change it on the other side as well. Even if we do keep them up to date, it is easy, especially if the server and the client are written in different languages, to have a slightly different interpertation of the logic on each end, whic, eventually, causes inconsistencies and bugs.</p>
+<p>The other use of Passable is server side validations. Since most of the times we perform validations, we send the data back to the server, we would like to perform the tests there as well. This causes a great deal of confusion and error. It is hard to keep the validations in the server and the client synced, so if we update a validation in the client side, or the server, it is easy to neglect and change it on the other side as well. Even if we do keep them up to date, it is easy, especially if the server and the client are written in different languages, to have a slightly different interpretation of the logic on each end, which, eventually, causes inconsistencies and bugs.</p>
 <p>Instead, with Passable, you could just as easily set up a data model validations server that would run the same exact validation code that runs in the browser. No duplication, no sync problems.</p>
 
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passable",
-  "version": "5.7.3",
+  "version": "5.7.4",
   "description": "Isomorphic Data Model Validations",
   "main": "./dist/Passable.min.js",
   "author": "Evyatar <evyatar.a@fiverr.com>",


### PR DESCRIPTION
Simple find and replace to find typos in the Passable documentation.

+ Upped a patch to update the README.md file on npm.