### PR TITLE
[REFACTOR] - passableArgs source code & tests

### DIFF
--- a/src/helpers/passable_args/index.js
+++ b/src/helpers/passable_args/index.js
@@ -25,11 +25,11 @@ function passableArgs(args: PassableArguments) {
 
     switch (args.length) {
       case 0:
-        throw new TypeError('Failed to execute `passableArgs`: At least 1 argument required, but only 0 present.')
+        throw new TypeError('[passable]: Failed to execute `passableArgs`: At least 1 argument required, but only 0 present.');
 
       case 1: // [passes] = args;
         if (typeof args[0] != 'function') {
-          throw new TypeError('Failed to execute `passableArgs`: Unexpected ' + typeof args[0]);
+          throw new TypeError('[passable]: Failed to execute `passableArgs`: Unexpected ' + typeof args[0] + ', expected function');
         }
         args = [specific, ...args];
 

--- a/src/helpers/passable_args/index.js
+++ b/src/helpers/passable_args/index.js
@@ -1,32 +1,46 @@
 // @flow
 
+/**
+ * The function which runs the validation tests.
+ *
+ * @callback passableCallback
+ * @param {function} pass
+ * @param {function} enforce
+ */
+
+/**
+ * Get Passable configuration settings
+ * specific - whitelist of tests to run
+ * passes - The function which runs the validations
+ * custom - custom validation rules
+ *
+ * @param {Array.<{specific: String[], passes: passableCallback, custom: Object}>} args - arguments for Passable configuration
+ * @return {object} Passable configuration settings
+ */
 function passableArgs(args: PassableArguments) {
 
     let passes: Function,
-        specific: specific,
-        custom: Rules | void;
+        specific: specific = [],
+        custom: Rules = {};
 
-    if (args.length === 1) {
-        passes = args[0];
-    } else if (args.length === 3) {
-        specific = args[0];
-        passes = args[1];
-        custom = args[2];
-    } else if (args.length === 2) {
-        if (typeof args[1] === 'function') {
-            specific = args[0];
-            passes = args[1];
-        } else {
-            passes = args[0];
-            custom = args[1];
+    switch (args.length) {
+      case 0:
+        throw new TypeError('Failed to execute `passableArgs`: At least 1 argument required, but only 0 present.')
+
+      case 1: // [passes] = args;
+        if (typeof args[0] != 'function') {
+          throw new TypeError('Failed to execute `passableArgs`: Unexpected ' + typeof args[0]);
         }
+        args = [specific, ...args];
+
+      case 2:
+        args = (typeof args[1] == 'function') ? [...args, custom] : [specific, ...args];
     }
 
-    specific = specific || [];
-    custom = custom || {};
+    [specific, passes, custom] = args;
 
     return {
-        passes, specific, custom
+        specific, passes, custom
     };
 };
 

--- a/src/helpers/passable_args/passable.helpers.args.spec.js
+++ b/src/helpers/passable_args/passable.helpers.args.spec.js
@@ -6,28 +6,37 @@ import chai from 'chai';
 const expect = chai.expect;
 
 describe('Test Passable arguments logic', () => {
+    const noop = () => {};
+
+    it('Should throw exception when given no arguments', () => {
+        expect(passableArgs.bind(null, [])).to.throw('Failed to execute `passableArgs`: At least 1 argument required, but only 0 present.');
+    });
+
+    it('Should throw exception when given only string argument', () => {
+        expect(passableArgs.bind(null, ['basic'])).to.throw('Failed to execute `passableArgs`: Unexpected string');
+    });
 
     it('Should return given "passes", default on specific and custom', () => {
-        const value = passableArgs(['basic']);
+        const value = passableArgs([noop]);
         expect(value).to.deep.equal({
-            passes: 'basic',
+            passes: noop,
             custom: {},
             specific: []
         });
     });
 
     it('Should return all attrs, not use default values', () => {
-        const value = passableArgs(['funny', 'yet', 'not']);
+        const yet = noop;
+        const value = passableArgs(['funny', yet, 'not']);
         expect(value).to.deep.equal({
             specific: 'funny',
-            passes: 'yet',
+            passes: yet,
             custom: 'not'
         });
     });
 
     it('Should return specific and passes, default on custom', () => {
-        const noop = () => undefined,
-            value = passableArgs([['Yo'], noop]);
+        const value = passableArgs([['Yo'], noop]);
         expect(value).to.deep.equal({
             specific: ['Yo'],
             passes: noop,

--- a/src/helpers/passable_args/passable.helpers.args.spec.js
+++ b/src/helpers/passable_args/passable.helpers.args.spec.js
@@ -9,11 +9,11 @@ describe('Test Passable arguments logic', () => {
     const noop = () => {};
 
     it('Should throw exception when given no arguments', () => {
-        expect(passableArgs.bind(null, [])).to.throw('Failed to execute `passableArgs`: At least 1 argument required, but only 0 present.');
+        expect(passableArgs.bind(null, [])).to.throw('passable]: Failed to execute `passableArgs`: At least 1 argument required, but only 0 present.');
     });
 
     it('Should throw exception when given only string argument', () => {
-        expect(passableArgs.bind(null, ['basic'])).to.throw('Failed to execute `passableArgs`: Unexpected string');
+        expect(passableArgs.bind(null, ['basic'])).to.throw('[passable]: Failed to execute `passableArgs`: Unexpected string, expected function');
     });
 
     it('Should return given "passes", default on specific and custom', () => {


### PR DESCRIPTION
The code is more readable now for `passableArgs` helper function. If there are less than 3 arguments, the `args` array builds gradually until it gets to the desired length.

The function now also allows 4 or more arguments without defaulting to the default values. Additional arguments are simply ignored.

I would throw errors if the wrong arguments are provided. Specifically if no arguments are provided or the required `passes` function is missing.
