### PR TITLE
Refactor aliases, global object, validations, anyOf, typeof

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["flow", "env"],
   "plugins": [
+    ["webpack-aliases", {"config": "webpack.config.js"}],
     "babel-plugin-add-module-exports",
     "transform-class-properties"
   ]

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,2 +1,8 @@
 [libs]
 src/types.js
+
+[options]
+module.name_mapper='^Root\/\(.*\)$' -> '<PROJECT_ROOT>/src/\1'
+module.name_mapper='^Root$' -> '<PROJECT_ROOT>/src'
+module.name_mapper='^Helpers\/\(.*\)$' -> '<PROJECT_ROOT>/src/helpers/\1'
+module.name_mapper='^Helpers$' -> '<PROJECT_ROOT>/src/helpers'

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-flowtype": "^2.35.0",
     "flow-bin": "^0.54.0",
     "mocha": "^3.5.3",
-    "webpack": "^3.5.5",
-    "window-or-global": "^1.0.1"
+    "webpack": "^3.5.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-loader": "^7.1.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-webpack-aliases": "^1.0.3",
     "babel-preset-env": "^1.6.0",
     "babel-preset-flow": "^6.23.0",
     "chai": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passable",
-  "version": "5.7.5",
+  "version": "5.7.6",
   "description": "Isomorphic Data Model Validations",
   "main": "./dist/Passable.min.js",
   "author": "Evyatar <evyatar.a@fiverr.com>",

--- a/src/Passable.js
+++ b/src/Passable.js
@@ -16,6 +16,9 @@ class Passable {
     enforce: Function;
 
     constructor(name: string, ...args) {
+        if (typeof name !== 'string') {
+          throw new TypeError(`[passable]: failed to execute 'Passable' constructor: Unexpected ${typeof name}, expected string`);
+        }
         const computedArgs: PassableRuntime = passableArgs(args),
             globalRules: Rules = root.customPassableRules || {};
 

--- a/src/Passable.js
+++ b/src/Passable.js
@@ -16,7 +16,7 @@ class Passable {
 
     constructor(name: string, ...args) {
         if (typeof name !== 'string') {
-            throw new TypeError(`[passable]: failed to execute 'Passable' constructor: Unexpected ${typeof name}, expected string`);
+            throw new TypeError(`[Passable]: failed to execute 'Passable' constructor: Unexpected ${typeof name}, expected string`);
         }
         const computedArgs: PassableRuntime = passableArgs(args),
             globalRules: Rules = root.customPassableRules || {};

--- a/src/Passable.js
+++ b/src/Passable.js
@@ -25,9 +25,7 @@ class Passable {
         this.pass = this.pass.bind(this);
         this.enforce = this.enforce.bind(this);
 
-        if (typeof computedArgs.passes === 'function') {
-            computedArgs.passes(this.pass, this.enforce);
-        }
+        computedArgs.passes(this.pass, this.enforce);
 
         return this.res;
     }

--- a/src/Passable.js
+++ b/src/Passable.js
@@ -16,7 +16,7 @@ class Passable {
 
     constructor(name: string, ...args) {
         if (typeof name !== 'string') {
-          throw new TypeError(`[passable]: failed to execute 'Passable' constructor: Unexpected ${typeof name}, expected string`);
+            throw new TypeError(`[passable]: failed to execute 'Passable' constructor: Unexpected ${typeof name}, expected string`);
         }
         const computedArgs: PassableRuntime = passableArgs(args),
             globalRules: Rules = root.customPassableRules || {};

--- a/src/Passable.js
+++ b/src/Passable.js
@@ -2,7 +2,7 @@
 
 import enforce from './enforce';
 import passRunner from './pass_runner';
-import { passableArgs, initResponseObject, initField, onFail, root } from './helpers';
+import { passableArgs, initResponseObject, initField, onFail, root } from 'Helpers';
 
 const FAIL: Severity = 'fail';
 

--- a/src/Passable.js
+++ b/src/Passable.js
@@ -2,8 +2,7 @@
 
 import enforce from './enforce';
 import passRunner from './pass_runner';
-import { passableArgs, initResponseObject, initField, onFail } from './helpers';
-import root from 'window-or-global';
+import { passableArgs, initResponseObject, initField, onFail, root } from './helpers';
 
 const FAIL: Severity = 'fail';
 

--- a/src/enforce/rules/helpers/expect_type/index.js
+++ b/src/enforce/rules/helpers/expect_type/index.js
@@ -2,13 +2,9 @@
 
 import { isType } from '../';
 
-function throwTypeError(value: AnyValue, type: string, functionName: string): void {
-    throw new TypeError(`${functionName}: expected ${value} to be a ${type}.`);
-}
-
 function expectType(value: mixed, type: string, functionName: string): true | void {
     if (!isType(value, type, true)) {
-        return throwTypeError(value, type, functionName);
+        throw new TypeError(`${functionName}: expected ${value} to be a ${type}.`);
     }
 
     return true;

--- a/src/enforce/rules/helpers/expect_type/index.js
+++ b/src/enforce/rules/helpers/expect_type/index.js
@@ -2,7 +2,7 @@
 
 import { isType } from '../';
 
-function expectType(value: mixed, type: string, functionName: string): true | void {
+function expectType(value: AnyValue, type: string, functionName: string): true | void {
     if (!isType(value, type, true)) {
         throw new TypeError(`${functionName}: expected ${value} to be a ${type}.`);
     }

--- a/src/enforce/runners/all_of/index.js
+++ b/src/enforce/runners/all_of/index.js
@@ -3,20 +3,11 @@ import run from '../run';
 
 export default function allOf(value: mixed, tests: Tests, rules: Rules): boolean {
 
-    const testsCount: number = Object.keys(tests).length;
-    let successCount: number = 0;
+    const validations: Array<string> = Object.keys(tests);
 
-    if (testsCount === 0) {
+    if (validations.length === 0) {
         return false;
     }
 
-    for (const key: string in tests) {
-        const success: boolean = run(value, key, tests, rules);
-
-        if (success === true) {
-            successCount++;
-        }
-    }
-
-    return successCount === testsCount;
+    return validations.every((key) => run(value, key, tests, rules) === true);
 }

--- a/src/enforce/runners/any_of/index.js
+++ b/src/enforce/runners/any_of/index.js
@@ -3,22 +3,6 @@ import run from '../run';
 
 export default function anyOf(value: mixed, tests: Tests, rules: Rules): boolean {
 
-    const testsCount: number = Object.keys(tests).length;
-    let successCount: number = 0;
-
-    if (testsCount === 0) {
-        return false;
-    }
-
-    for (const key: string in tests) {
-
-        const success: boolean = run(value, key, tests, rules);
-
-        if (success === true) {
-            successCount++;
-            break;
-        }
-    }
-
-    return successCount > 0;
+    const validations: Array<string> = Object.keys(tests);
+    return validations.some((key) => run(value, key, tests, rules) === true);
 }

--- a/src/enforce/runners/any_of/index.js
+++ b/src/enforce/runners/any_of/index.js
@@ -16,7 +16,7 @@ export default function anyOf(value: mixed, tests: Tests, rules: Rules): boolean
 
         if (success === true) {
             successCount++;
-            continue;
+            break;
         }
     }
 

--- a/src/enforce/runners/none_of/index.js
+++ b/src/enforce/runners/none_of/index.js
@@ -3,23 +3,11 @@ import run from '../run';
 
 export default function noneOf(value: mixed, tests: Tests, rules: Rules): boolean {
 
-    const testsCount: number = Object.keys(tests).length;
-    let failCount: number = 0;
+    const validations: Array<string> = Object.keys(tests);
 
-    if (testsCount === 0) {
+    if (validations.length === 0) {
         return false;
     }
 
-    for (const key: string in tests) {
-
-        const success: boolean = run(value, key, tests, rules);
-
-        if (success === true) {
-            continue;
-        } else {
-            failCount++;
-        }
-    }
-
-    return failCount === testsCount;
+    return validations.every((key) => run(value, key, tests, rules) !== true);
 }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -3,10 +3,12 @@ import passableArgs from './passable_args';
 import initResponseObject from './init_response_object';
 import initField from './init_field';
 import onFail from './on_fail';
+import root from './root';
 
 export {
     passableArgs,
     initResponseObject,
     initField,
-    onFail
+    onFail,
+    root
 };

--- a/src/helpers/passable_args/index.js
+++ b/src/helpers/passable_args/index.js
@@ -19,8 +19,8 @@
  */
 function passableArgs(args: PassableArguments): PassableRuntime {
 
-    let passes: Passes,
-        specific: Specific = [],
+    let specific: Specific = [],
+        passes: Passes,
         custom: Rules = {};
 
     let res: [Array<string> | string, Passes, Rules];
@@ -44,14 +44,14 @@ function passableArgs(args: PassableArguments): PassableRuntime {
                 // [passes, custom]
                 res = typeof args[1] === 'object' && !Array.isArray(args[1]) ? [specific, args[0], args[1]] : [specific, args[0], custom];
             } else {
-                throw new TypeError("[Passable]: Failed to execute 'passableArgs': Unexpected argument, expected function at positon '1' or '2'");
+                throw new TypeError("[Passable]: Failed to execute 'passableArgs': Unexpected argument, expected function at position '1' or '2'");
             }
             break;
         case 3: // [specific, passes, custom]
         default:
             if (typeof args[1] !== 'function') {
                 // [specific, ?, custom]
-                throw new TypeError("[Passable]: Failed to execute 'passableArgs': Unexpected argument, expected function at positon '2'");
+                throw new TypeError("[Passable]: Failed to execute 'passableArgs': Unexpected argument, expected function at position '2'");
             } else if (!(typeof args[0] === 'string' || Array.isArray(args[0])) || !(typeof args[2] === 'object' && !Array.isArray(args[2]))) {
                 // [?, passes, ?]
                 throw new TypeError("[Passable]: Failed to execute 'passableArgs': Unexpected set of arguments. Expected: Specific, Passes, Custom");

--- a/src/helpers/passable_args/passable.helpers.args.spec.js
+++ b/src/helpers/passable_args/passable.helpers.args.spec.js
@@ -63,7 +63,7 @@ describe('Test Passable arguments logic', () => {
     });
 
     it('Should throw an exception when passes is not a function', () => {
-        expect(passableArgs.bind(null, [[], 'noop', {}])).to.throw("[Passable]: Failed to execute 'passableArgs': Unexpected argument, expected function at positon '2'");
+        expect(passableArgs.bind(null, [[], 'noop', {}])).to.throw("[Passable]: Failed to execute 'passableArgs': Unexpected argument, expected function at position '2'");
     });
 
     it('Should throw an exception if either specific or custom are of wrong types', () => {
@@ -73,7 +73,7 @@ describe('Test Passable arguments logic', () => {
     });
 
     it('Should throw an exception if two arguments are passed, with no function', () => {
-        expect(passableArgs.bind(null, [[], {}])).to.throw("[Passable]: Failed to execute 'passableArgs': Unexpected argument, expected function at positon '1' or '2'");
-        expect(passableArgs.bind(null, ['noop', {}])).to.throw("[Passable]: Failed to execute 'passableArgs': Unexpected argument, expected function at positon '1' or '2'");
+        expect(passableArgs.bind(null, [[], {}])).to.throw("[Passable]: Failed to execute 'passableArgs': Unexpected argument, expected function at position '1' or '2'");
+        expect(passableArgs.bind(null, ['noop', {}])).to.throw("[Passable]: Failed to execute 'passableArgs': Unexpected argument, expected function at position '1' or '2'");
     });
 });

--- a/src/helpers/root.js
+++ b/src/helpers/root.js
@@ -1,5 +1,5 @@
 // @flow
-let root: object;
+let root: AnyValue;
 
 // credit https://stackoverflow.com/questions/3277182/how-to-get-the-global-object-in-javascript
 try {

--- a/src/helpers/root.js
+++ b/src/helpers/root.js
@@ -1,11 +1,11 @@
 // @flow
-let root;
+let root: object;
 
 // credit https://stackoverflow.com/questions/3277182/how-to-get-the-global-object-in-javascript
 try {
-  root = (() => {}).constructor('return this')();
-} catch(e) {
-  root = window;
+    root = (() => undefined).constructor('return this')();
+} catch (e) {
+    root = window;
 }
 
 export default root;

--- a/src/helpers/root.js
+++ b/src/helpers/root.js
@@ -1,0 +1,11 @@
+// @flow
+let root;
+
+// credit https://stackoverflow.com/questions/3277182/how-to-get-the-global-object-in-javascript
+try {
+  root = (() => {}).constructor('return this')();
+} catch(e) {
+  root = window;
+}
+
+export default root;

--- a/src/spec/passable.api.global-custom.spec.js
+++ b/src/spec/passable.api.global-custom.spec.js
@@ -2,7 +2,7 @@
 
 import passable from '../Passable';
 import chai from 'chai';
-import { root } from '../helpers';
+import { root } from 'Helpers';
 
 const expect = chai.expect;
 

--- a/src/spec/passable.api.global-custom.spec.js
+++ b/src/spec/passable.api.global-custom.spec.js
@@ -2,7 +2,7 @@
 
 import passable from '../Passable';
 import chai from 'chai';
-import root from 'window-or-global';
+import { root } from '../helpers';
 
 const expect = chai.expect;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,8 @@ const config = {
     },
     resolve: {
         alias: {
-            root: path.resolve('./src')
+            Root: path.resolve('./src'),
+            Helpers: path.resolve('./src/helpers')
         }
     },
     plugins


### PR DESCRIPTION
Webpack aliases now work for tests after adding `babel-plugin-webpack-aliases`.

Added Helpers alias.

The `window-or-global` package was replaced with a more robust way to get the global object.

Now validating form name argument exists.

Validation for `passes` function moved to `passableArgs`.

~~Added types helper function `isFunction`. To avoid repeating `typeof arg == 'function'`.
This can be extended to other types of course.~~

`anyOf` runner now stops after finding first match. 
`allOf` runner returns false immediately on any failed test
`noneOf` runner returns false immediately on any successful test

Refactor `enforce` runners