### PR TITLE
Removing src dir from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 .vscode
 node_modules
 spec
-src
 dev
 .babelrc
 .eslintignore

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passable",
-  "version": "5.7.6",
+  "version": "5.7.7",
   "description": "Isomorphic Data Model Validations",
   "main": "./dist/Passable.min.js",
   "author": "Evyatar <evyatar.a@fiverr.com>",


### PR DESCRIPTION
Unignoring src directory from npmignore so that consumers may use the non-minified, non-transpiled version of Passable, determining themselves their es support level, and getting easier debug while at it.