### PR TITLE
[Minor] Add default expect=true to rules

### DIFF
--- a/src/enforce/rules/lang/is_array/index.js
+++ b/src/enforce/rules/lang/is_array/index.js
@@ -1,7 +1,7 @@
 // @flow
 import { isType, expectType } from '../../helpers';
 
-function isArray(value: mixed, expect: boolean): boolean {
+function isArray(value: mixed, expect: boolean = true): boolean {
     expectType(expect, 'boolean', 'isArray');
     return isType(value, 'array') === expect;
 }

--- a/src/enforce/rules/lang/is_number/index.js
+++ b/src/enforce/rules/lang/is_number/index.js
@@ -2,7 +2,7 @@
 
 import { isType, expectType } from '../../helpers';
 
-function isNumber(value: mixed, expect: boolean): boolean {
+function isNumber(value: mixed, expect: boolean = true): boolean {
     expectType(expect, 'boolean', 'isNumber');
     return isType(value, 'number') === expect;
 }

--- a/src/enforce/rules/lang/is_string/index.js
+++ b/src/enforce/rules/lang/is_string/index.js
@@ -1,7 +1,7 @@
 // @flow
 import { isType, expectType } from '../../helpers';
 
-function isString(value: mixed, expect: boolean): boolean {
+function isString(value: mixed, expect: boolean = true): boolean {
     expectType(expect, 'boolean', 'isString');
     return isType(value, 'string') === expect;
 }

--- a/src/enforce/rules/size/is_empty/index.js
+++ b/src/enforce/rules/size/is_empty/index.js
@@ -1,7 +1,7 @@
 // @flow
 import { expectType, getSize } from '../../helpers';
 
-function isEmpty(value: mixed, expect: boolean): boolean {
+function isEmpty(value: mixed, expect: boolean = true): boolean {
     expectType(expect, 'boolean', 'isEmpty');
 
     return (getSize(value) === 0) === expect;


### PR DESCRIPTION
Adding default expect to rules that expect a boolean **as a modifier**. Adding a default true to functions that use the value to understand whether to flip the result or not.

All these functions are phrased as `true`, and the default behavior should mark that.

This makes no difference to classic - compound functions, as they had to supply a value to operate, but it does simplify writing tests in the new flat enforce syntax.