### PR TITLE
Fix wrong path for dist entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "passable",
-  "version": "6.1.1",
+  "version": "6.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "passable",
-  "version": "6.0.7",
+  "version": "6.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "passable",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Isomorphic Data Model Validations",
-  "main": "./dist/Passable.min.js",
+  "main": "./dist/passable.min.js",
   "author": "Evyatar <evyatar.a@fiverr.com>",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passable",
-  "version": "6.1.1",
+  "version": "6.1.0",
   "description": "Isomorphic Data Model Validations",
   "main": "./dist/passable.min.js",
   "author": "Evyatar <evyatar.a@fiverr.com>",


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | yes
| New feature?     | no
| Breaking change? | no
| Deprecations?    | no
| Documentation?   | no
| Tests added?     | no
| Fixed issues     | wrong main entry point in package.json

The main entry point in `package.json` currently points to `./dist/Passable.min.js` - the dist file, however, uses all lowercase (`passable.min.js`).

This causes webpack builds to fail if they're using the `CaseSensitivePathsPlugin`.
