### PR TITLE
[Patch] Publish next tag separately from feature branch 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,19 @@ deploy:
     email: evyatar.a@fiverr.com
     skip_cleanup: true
     api_key: $NPM_TOKEN
-    tag: "next-${TRAVIS_COMMIT:(-6)}"
+    tag: "next"
     on:
       all_branches: true
-      condition: $TRAVIS_BRANCH != "master"
+      condition: $TRAVIS_BRANCH = "next"
+      repo: fiverr/passable
+      node: '8'
+  - provider: npm
+    email: evyatar.a@fiverr.com
+    skip_cleanup: true
+    api_key: $NPM_TOKEN
+    tag: "${TRAVIS_COMMIT:(-6)}"
+    on:
+      all_branches: true
+      condition: $TRAVIS_BRANCH != "next" && $TRAVIS_BRANCH != "master"
       repo: fiverr/passable
       node: '8'


### PR DESCRIPTION
This will publish `next` tag only for `next` branch. Each feature branch will be tagged with its own commit id.