### PR TITLE
[Minor] add hasErrors and hasWarnings functions

### DIFF
--- a/documentation/getting_started/result.md
+++ b/documentation/getting_started/result.md
@@ -3,21 +3,23 @@
 ## Properties
 | Name                             | Type       | Description                                         |
 |----------------------------------|------------|-----------------------------------------------------|
-| `name`                           | `String`   | The name of the form being validated                |
-| `hasValidationErrors`            | `Boolean`  | Whether there are validation errors or not          |
-| `hasValidationWarnings`          | `Boolean`  | Whether there are validation warnings or not        |
-| `failCount`                      | `Number`   | Overall errors count for this form                  |
-| `warnCount`                      | `Number`   | Overall warnings count for this form                |
-| `testCount`                      | `Number`   | Overall test count in this form                     |
-| `testsPerformed`                 | `Object{}` | Detailed stats per field (structure detailed below) |
-| `validationErrors`               | `Object[]` | Actual errors per each field                        |
-| `validationErrors[field-name]`   | `Object[]` | All error strings for this field                    |
-| `validationWarnings`             | `Object[]` | Actual errors per each field                        |
-| `validationWarnings[field-name]` | `Object[]` | All warning strings for this field                  |
-| `async`                          | `Object{}` | Contains async tests and their current completion status |
-| `skipped`                        | `Array`    | All skipped fields (empty, unless the `specific` option is used) |
-| `getErrors`                      | `Function` | Getter function which allows accessing the errors array of one or all fields |
-| `getWarnings`                    | `Function` | Getter function which allows accessing the warnings array of one or all fields |
+| `name`                           | `String`   | The name of the form being validated
+| `hasValidationErrors`            | `Boolean`  | Whether there are validation errors or not
+| `hasValidationWarnings`          | `Boolean`  | Whether there are validation warnings or not
+| `failCount`                      | `Number`   | Overall errors count for this form
+| `warnCount`                      | `Number`   | Overall warnings count for this form
+| `testCount`                      | `Number`   | Overall test count in this form
+| `testsPerformed`                 | `Object{}` | Detailed stats per field (structure detailed below)
+| `validationErrors`               | `Object[]` | Actual errors per each field
+| `validationErrors[field-name]`   | `Object[]` | All error strings for this field
+| `validationWarnings`             | `Object[]` | Actual errors per each field
+| `validationWarnings[field-name]` | `Object[]` | All warning strings for this field
+| `async`                          | `Object{}` | Contains async tests and their current completion status
+| `skipped`                        | `Array`    | All skipped fields (empty, unless the `specific` option is used)
+| `getErrors`                      | `Function` | Getter function which allows accessing the errors array of one or all fields
+| `getWarnings`                    | `Function` | Getter function which allows accessing the warnings array of one or all fields
+| `hasErrors`                      | `Function` | Returns whether a certain field (or the whole suite, if no field passed) has errors
+| `hasWarnings`                    | `Function` | Returns whether a certain field (or the whole suite, if no field passed) has warnings
 
 ### `testsPerformed` field structure
 | Name        | Type     | Description                           |
@@ -26,29 +28,53 @@
 | `warnCount` | `Number` | Overall warnings count for this field |
 | `testCount` | `Number` | Overall test count in this field      |
 
+## `hasErrors` and `hasWarnings` functions
+> since 6.3.0
+
+If you only need to know if a certain field has validation errors or warnings, but don't really care which they are, you can use `hasErrors` or `hasWarnings` functions.
+
+```js
+resultObject.hasErrors('username');
+// true
+
+resultObject.hasWarnings('password');
+// false
+```
+
+In case you want to know whether the whole suite has errors or warnings, you can use the same functions, just without specifying a field
+
+```js
+resultObject.hasErrors();
+// true
+
+resultObject.hasWarnings();
+// true
+```
+
 ## `getErrors` and `getWarnings` functions
 > since 5.10.0
 
 You can easily traverse the object tree to acess the field errors and warnings, but when accessing many fields, it can get pretty messy:
+
 ```js
 resultObject.validationErrors.myField && resultObject.validationErrors.myField[0];
 ```
 This is clearly not ideal. There is a shortcut to getting to a specific field:
 
 ```js
-resultObject.getErrors('fieldName');
+resultObject.getErrors('username');
 // ['Error string 1', `Error string 2`]
 
-resultObject.getWarnings('fieldName');
+resultObject.getWarnings('password');
 // ['Warning string 1', `Warning string 2`]
 ```
 
 If there are no errors for the field, the function returns an empty array:
 ```js
-resultObject.getErrors('fieldName');
+resultObject.getErrors('username');
 // []
 
-resultObject.getWarnings('fieldName');
+resultObject.getWarnings('username');
 // []
 ```
 

--- a/src/result_object/index.js
+++ b/src/result_object/index.js
@@ -163,7 +163,7 @@ class ResultObject {
     }
 
     /**
-     * Getall the errors of a field, or of the whole object
+     * Gets all the errors of a field, or of the whole object
      * @param {string} [fieldName] - The name of the field.
      * @return {Array | Object} The field's errors, or all errors
      */
@@ -180,7 +180,7 @@ class ResultObject {
     }
 
     /**
-     * Getall the warnings of a field, or of the whole object
+     * Gets all the warnings of a field, or of the whole object
      * @param {string} [fieldName] - The name of the field.
      * @return {Array | Object} The field's warnings, or all warnings
      */
@@ -194,6 +194,34 @@ class ResultObject {
         }
 
         return [];
+    }
+
+    /**
+     * Returns whether a field (or the whole suite, if none passed) contains errors
+     * @param {string} [fieldName]
+     */
+    hasErrors(fieldName: string): boolean {
+        if (!fieldName) {
+            return this.hasValidationErrors;
+        }
+
+        return this.validationErrors[fieldName]
+            ? Boolean(this.validationErrors[fieldName].length)
+            : false;
+    }
+
+    /**
+     * Returns whether a field (or the whole suite, if none passed) contains warnings
+     * @param {string} [fieldName]
+     */
+    hasWarnings(fieldName: string): boolean {
+        if (!fieldName) {
+            return this.hasValidationWarnings;
+        }
+
+        return this.validationWarnings[fieldName]
+            ? Boolean(this.validationWarnings[fieldName].length)
+            : false;
     }
 
     async: AsyncObject;

--- a/src/result_object/spec.js
+++ b/src/result_object/spec.js
@@ -25,7 +25,7 @@ describe('class: PassableResponse', () => {
     });
 
 
-    ['done', 'getErrors', 'getWarnings'].forEach((method) => {
+    ['done', 'getErrors', 'getWarnings', 'hasErrors', 'hasWarnings'].forEach((method) => {
         it(`Should expose ${method} method`, () => {
             const res = new ResultObject(faker.lorem.word());
             expect(typeof res[method]).to.equal('function');
@@ -218,6 +218,58 @@ describe('class: PassableResponse', () => {
         it('Should return all errors object when no field specified', () => {
             expect(testObject.getWarnings()).to.deep.equal({
                 example: ['Error string']
+            });
+        });
+    });
+
+    describe('method: hasErrors', () => {
+        let testObject;
+        beforeEach(() => {
+            testObject = new ResultObject('FormName')
+                .initFieldCounters('example')
+                .initFieldCounters('example_2')
+                .fail('example', 'Error string', FAIL);
+        });
+
+        describe('Fiels specified', () => {
+            it('Should return errors array for a field with errors', () => {
+                expect(testObject.hasErrors('example')).to.equal(true);
+            });
+
+            it('Should return empty array for a field with no errors', () => {
+                expect(testObject.hasErrors('example_2')).to.equal(false);
+            });
+        });
+
+        describe('Field not specified', () => {
+            it('Should return all errors object', () => {
+                expect(testObject.hasErrors()).to.equal(true);
+            });
+        });
+    });
+
+    describe('method: hasWarnings', () => {
+        let testObject;
+        beforeEach(() => {
+            testObject = new ResultObject('FormName')
+                .initFieldCounters('example')
+                .initFieldCounters('example_2')
+                .fail('example', 'Error string', WARN);
+        });
+
+        describe('Fiels specified', () => {
+            it('Should return errors array for a field with errors', () => {
+                expect(testObject.hasWarnings('example')).to.equal(true);
+            });
+
+            it('Should return empty array for a field with no errors', () => {
+                expect(testObject.hasWarnings('example_2')).to.equal(false);
+            });
+        });
+
+        describe('Field not specified', () => {
+            it('Should return all errors object', () => {
+                expect(testObject.hasWarnings()).to.equal(true);
             });
         });
     });


### PR DESCRIPTION
<!--
Before creating a pull request, please read our contributing guidelines:

CONTRIBUTING.md

Remember: Unless it is an urgent bugfix, please use `next` as the base for your PR

Please fill the following form (leave what's relevant)
-->

| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | yes
| Breaking change? | no
| Deprecations?    | no
| Documentation?   | yes
| Tests added?     | yes

<!-- Describe your changes below in detail. -->

This feature goes hand in hand with https://github.com/fiverr/passable/pull/103 as it further simplifies skipping a certain test in case of an existing error.

```js
passable('NewUserForm', (test, draft) => {
    test('username', 'Must be a string between 2 and 10 chars', () => {
        enforce(data.username).isString().largerThan(1).smallerThan(11);
    });

    if (!draft.hasErrors('username')) {
        // if the username did not pass the previous test, the following test won't run
        test('username', 'already exists', fetch(`/check_availability?username=${data.username}`));
    }
});
```

# doc:

## `hasErrors` and `hasWarnings` functions
> since 6.3.0

If you only need to know if a certain field has validation errors or warnings but don't really care which they are, you can use `hasErrors` or `hasWarnings` functions.

```js
resultObject.hasErrors('username');
// true

resultObject.hasWarnings('password');
// false
```

In case you want to know whether the whole suite has errors or warnings, you can use the same functions, just without specifying a field

```js
resultObject.hasErrors();
// true

resultObject.hasWarnings();
// true
```